### PR TITLE
Cache AppSettings in static class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,7 +130,7 @@ publish/
 
 # NuGet Packages Directory
 ## TODO: If you have NuGet Package Restore enabled, uncomment the next line
-#packages/
+packages/
 
 # Windows Azure Build Output
 csx
@@ -213,3 +213,4 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+

--- a/Daishi.Armor.WebFramework/ArmorAuthorize.cs
+++ b/Daishi.Armor.WebFramework/ArmorAuthorize.cs
@@ -1,8 +1,6 @@
 ﻿#region Includes
 
-using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Linq;
 using System.Security.Claims;
 
@@ -50,14 +48,9 @@ namespace Daishi.Armor.WebFramework {
 
             #region Validate ArmorToken
 
-            var encryptionKey =
-                Convert.FromBase64String(
-                    ConfigurationManager.AppSettings["ArmorEncryptionKey"]);
-            var hashingKey =
-                Convert.FromBase64String(
-                    ConfigurationManager.AppSettings["ArmorHashKey"]);
-            var armorTimeOut =
-                Convert.ToInt64(ConfigurationManager.AppSettings["ArmorTimeout"]);
+            var encryptionKey = ArmorSettings.EncryptionKey;
+            var hashingKey = ArmorSettings.HashingKey;
+            var armorTimeOut = ArmorSettings.Timeout;
 
             var secureArmorTokenValidator =
                 new SecureArmorTokenValidator(armorTokenHeader.ArmorToken,

--- a/Daishi.Armor.WebFramework/ArmorFortify.cs
+++ b/Daishi.Armor.WebFramework/ArmorFortify.cs
@@ -1,8 +1,6 @@
 ﻿#region Includes
 
-using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Linq;
 using System.Security.Claims;
 using System.Web;
@@ -32,12 +30,8 @@ namespace Daishi.Armor.WebFramework {
             var userId = claims.Single(c => c.Type.Equals("UserId")).Value;
             var platform = claims.Single(c => c.Type.Equals("Platform")).Value;
 
-            var encryptionKey =
-                Convert.FromBase64String(
-                    ConfigurationManager.AppSettings["ArmorEncryptionKey"]);
-            var hashingKey =
-                Convert.FromBase64String(
-                    ConfigurationManager.AppSettings["ArmorHashKey"]);
+            var encryptionKey = ArmorSettings.EncryptionKey;
+            var hashingKey = ArmorSettings.HashingKey;
 
             var nonceGenerator = new NonceGenerator();
             nonceGenerator.Execute();

--- a/Daishi.Armor.WebFramework/ArmorSettings.cs
+++ b/Daishi.Armor.WebFramework/ArmorSettings.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Configuration;
+
+namespace Daishi.Armor.WebFramework {
+    // Since changes to the AppSettings will bounce the AppDomain, we can statically
+    // cache the answer to all this configuration settings
+    public static class ArmorSettings {
+        private static byte[] s_EncryptionKey;
+        public static byte[] EncryptionKey {
+            get {
+                if (s_EncryptionKey == null) {
+                    s_EncryptionKey = Convert.FromBase64String(
+                        ConfigurationManager.AppSettings["ArmorEncryptionKey"]);
+                }
+
+                return s_EncryptionKey;
+            }
+        }
+
+        private static byte[] s_HashingKey;
+        public static byte[] HashingKey {
+            get {
+                if (s_HashingKey == null) {
+                    s_HashingKey = Convert.FromBase64String(
+                    ConfigurationManager.AppSettings["ArmorHashKey"]);
+                }
+
+                return s_HashingKey;
+            }
+        }
+
+        private static long? s_Timeout;
+        public static long Timeout {
+            get {
+                if (!s_Timeout.HasValue) {
+                    s_Timeout = Convert.ToInt64(
+                        ConfigurationManager.AppSettings["ArmorTimeout"]);
+                }
+
+                return s_Timeout.Value;
+            }
+        }
+
+        private static bool? s_IsArmed;
+        public static bool IsArmed {
+            get {
+                if (!s_IsArmed.HasValue) {
+                    s_IsArmed = Convert.ToBoolean(
+                        ConfigurationManager.AppSettings["IsArmed"]);
+                }
+
+                return s_IsArmed.Value;
+            }
+        }
+    }
+}

--- a/Daishi.Armor.WebFramework/Daishi.Armor.WebFramework.csproj
+++ b/Daishi.Armor.WebFramework/Daishi.Armor.WebFramework.csproj
@@ -87,6 +87,7 @@
   <ItemGroup>
     <Compile Include="ArmorAuthorize.cs" />
     <Compile Include="ArmorFortify.cs" />
+    <Compile Include="ArmorSettings.cs" />
     <Compile Include="ArmorTokenHeader.cs" />
     <Compile Include="GenerateSecureArmorToken.cs" />
     <Compile Include="HttpRequestArmorHeaderParser.cs" />

--- a/Daishi.Armor.WebFramework/MvcArmorAuthorizeAttribute.cs
+++ b/Daishi.Armor.WebFramework/MvcArmorAuthorizeAttribute.cs
@@ -1,7 +1,5 @@
 ﻿#region Includes
 
-using System;
-using System.Configuration;
 using System.Threading;
 using System.Web;
 using System.Web.Mvc;
@@ -11,9 +9,7 @@ using System.Web.Mvc;
 namespace Daishi.Armor.WebFramework {
     public class MvcArmorAuthorizeAttribute : AuthorizeAttribute {
         protected override bool AuthorizeCore(HttpContextBase httpContext) {
-            var isArmed =
-                Convert.ToBoolean(ConfigurationManager.AppSettings["IsArmed"]);
-            if (!isArmed) return true;
+            if (!ArmorSettings.IsArmed) return true;
 
             var armorAuthorize =
                 new ArmorAuthorize(

--- a/Daishi.Armor.WebFramework/MvcArmorFortifyFilter.cs
+++ b/Daishi.Armor.WebFramework/MvcArmorFortifyFilter.cs
@@ -1,7 +1,5 @@
 ﻿#region Includes
 
-using System;
-using System.Configuration;
 using System.Web.Mvc;
 
 #endregion
@@ -10,9 +8,7 @@ namespace Daishi.Armor.WebFramework {
     public class MvcArmorFortifyFilter : ActionFilterAttribute {
         public override void OnActionExecuted(
             ActionExecutedContext filterContext) {
-            var isArmed =
-                Convert.ToBoolean(ConfigurationManager.AppSettings["IsArmed"]);
-            if (!isArmed) return;
+            if (!ArmorSettings.IsArmed) return;
 
             var armorFortify =
                 new ArmorFortify(

--- a/Daishi.Armor.WebFramework/WebApiArmorAuthorizeAttribute.cs
+++ b/Daishi.Armor.WebFramework/WebApiArmorAuthorizeAttribute.cs
@@ -1,7 +1,5 @@
 ﻿#region Includes
 
-using System;
-using System.Configuration;
 using System.Threading;
 using System.Web.Http;
 using System.Web.Http.Controllers;
@@ -11,9 +9,7 @@ using System.Web.Http.Controllers;
 namespace Daishi.Armor.WebFramework {
     public class WebApiArmorAuthorizeAttribute : AuthorizeAttribute {
         protected override bool IsAuthorized(HttpActionContext actionContext) {
-            var isArmed =
-                Convert.ToBoolean(ConfigurationManager.AppSettings["IsArmed"]);
-            if (!isArmed) return true;
+            if (!ArmorSettings.IsArmed) return true;
 
             var armorAuthorize =
                 new ArmorAuthorize(

--- a/Daishi.Armor.WebFramework/WebApiArmorFortifyFilter.cs
+++ b/Daishi.Armor.WebFramework/WebApiArmorFortifyFilter.cs
@@ -1,7 +1,5 @@
 ﻿#region Includes
 
-using System;
-using System.Configuration;
 using System.Net;
 using System.Threading;
 using System.Web;
@@ -14,9 +12,7 @@ namespace Daishi.Armor.WebFramework {
     public class WebApiArmorFortifyFilter : ActionFilterAttribute {
         public override void OnActionExecuted(
             HttpActionExecutedContext actionExecutedContext) {
-            var isArmed =
-                Convert.ToBoolean(ConfigurationManager.AppSettings["IsArmed"]);
-            if (!isArmed) return;
+            if (!ArmorSettings.IsArmed) return;
 
             var armorFortify =
                 new ArmorFortify(


### PR DESCRIPTION
Since the AppDomain will automatically recycle when changes are made to the AppSettings (web.config/app.config) it is safe to cache the setting values. This ensures we only do the conversion once and allocate the byte arrays once. This will greatly reduce the number of allocations in the critical path of Filters and Attributes.
